### PR TITLE
Added the option to allow only a set of activation functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build:src": "ts-node scripts/build.ts",
     "deploy:docs": "tsc --declaration && jsdoc -c jsdoc.json -d ./theme/static/versions/${npm_package_version}/",
-    "test": "mocha --require ts-node/register test/**/*",
+    "test": "tsc && mocha build/test/**/*",
     "test-parallel": "mocha-parallel-tests --require ts-node/register test/**/*",
     "lint": "tslint --project ./",
     "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls build/src"

--- a/src/NEAT.ts
+++ b/src/NEAT.ts
@@ -9,6 +9,7 @@ import {
     FEEDFORWARD_MUTATIONS,
     Mutation
 } from "./methods/Mutation";
+import {ActivationType, ALL_ACTIVATIONS} from "./methods/Activation";
 
 /**
  * Runs the NEAT algorithm on group of neural networks.
@@ -73,6 +74,7 @@ export class NEAT {
     private readonly maxGates: number;
     private population: Network[];
     private readonly dataset: { input: number[]; output: number[] }[];
+    private activations: ActivationType[];
 
     constructor(dataset: { input: number[], output: number[] }[], options: EvolveOptions = {}) {
         if (dataset.length === 0) {
@@ -97,6 +99,7 @@ export class NEAT {
 
         this.selection = getOrDefault(options.selection, new FitnessProportionateSelection());
         this.mutations = getOrDefault(options.mutations, FEEDFORWARD_MUTATIONS);
+        this.activations = getOrDefault(options.activations, ALL_ACTIVATIONS);
         this.template = getOrDefault(options.template, new Network(this.input, this.output));
         this.maxNodes = getOrDefault(options.maxNodes, Infinity);
         this.maxConnections = getOrDefault(options.maxConnections, Infinity);
@@ -134,7 +137,7 @@ export class NEAT {
             );
         });
 
-        genome.mutate(pickRandom(possible));
+        genome.mutate(pickRandom(possible), {allowedActivations: this.activations});
     }
 
     /**

--- a/src/architecture/Network.ts
+++ b/src/architecture/Network.ts
@@ -8,6 +8,7 @@ import {NEAT} from "../NEAT";
 import {Selection} from "../methods/Selection";
 import {Pool, spawn, Worker} from "threads";
 import "threads/register";
+import {ActivationType} from "../methods/Activation";
 
 /**
  * Create a neural network
@@ -562,7 +563,7 @@ export class Network {
      *
      * myNetwork = myNetwork.mutate(new AddNodeMutation()) // returns a mutated network with an added gate
      */
-    public mutate(method: Mutation, options?: { maxNodes?: number, maxConnections?: number, maxGates?: number }): void {
+    public mutate(method: Mutation, options?: { maxNodes?: number, maxConnections?: number, maxGates?: number, allowedActivations?: ActivationType[] }): void {
         method.mutate(this, options);
     }
 
@@ -1087,6 +1088,7 @@ export interface EvolveOptions {
     generation?: number;
     template?: Network;
     mutations?: Mutation[];
+    activations?: ActivationType[];
     selection?: Selection;
     mutationRate?: number;
     mutationAmount?: number;

--- a/src/architecture/Network.ts
+++ b/src/architecture/Network.ts
@@ -977,6 +977,7 @@ export class Network {
         options.maxNodes = getOrDefault(options.maxNodes, Infinity);
         options.maxConnections = getOrDefault(options.maxConnections, Infinity);
         options.maxGates = getOrDefault(options.maxGates, Infinity);
+        options.threads = getOrDefault(options.threads, 4);
 
         const start: number = Date.now();
 
@@ -992,7 +993,7 @@ export class Network {
             // create default one
 
             // init a pool of workers
-            workerPool = options.threads ? Pool(() => spawn(new Worker("../multithreading/Worker")), options.threads) : Pool(() => spawn(new Worker("../multithreading/Worker")));
+            workerPool = Pool(() => spawn(new Worker("../multithreading/Worker")), options.threads);
 
             options.fitnessFunction = async function (dataset: { input: number[], output: number[] }[], population: Network[]): Promise<void> {
                 for (const genome of population) {

--- a/src/architecture/Node.ts
+++ b/src/architecture/Node.ts
@@ -170,10 +170,13 @@ export class Node {
      *
      * node.mutateBias(); // Changes node's activation function
      */
-    public mutateActivation(): void {
-        // pick a random activation except the current activation
-        const newActivationType: ActivationType = pickRandom(ALL_ACTIVATIONS.filter(activation => activation !== this.squash.type));
-        this.squash = Activation.getActivation(newActivationType);
+    public mutateActivation(allowedActivations: ActivationType[] = ALL_ACTIVATIONS): void {
+        // pick a random activation from allowed activations except the current activation
+        const possible: ActivationType[] = allowedActivations.filter(activation => activation !== this.squash.type);
+        if (possible.length > 0) {
+            const newActivationType: ActivationType = pickRandom(possible);
+            this.squash = Activation.getActivation(newActivationType);
+        }
     }
 
     /**

--- a/src/methods/Mutation.ts
+++ b/src/methods/Mutation.ts
@@ -1,7 +1,7 @@
 import {Connection, Network} from "..";
 import {Node, NodeType} from "../architecture/Node";
 import {pickRandom, randBoolean, randDouble} from "./Utils";
-import {Activation} from "./Activation";
+import {Activation, ActivationType} from "./Activation";
 
 /**
  *
@@ -35,7 +35,7 @@ export abstract class Mutation {
      * @param network the network to mutate
      * @param options you can set the max amount of nodes, connections and gates
      */
-    public abstract mutate(network: Network, options?: { maxNodes?: number; maxConnections?: number; maxGates?: number }): void;
+    public abstract mutate(network: Network, options?: { maxNodes?: number; maxConnections?: number; maxGates?: number, allowedActivations?: ActivationType[] }): void;
 }
 
 /**
@@ -59,7 +59,7 @@ export class AddNodeMutation extends Mutation {
         this.randomActivation = randomActivation;
     }
 
-    public mutate(network: Network, options?: { maxNodes?: number; maxConnections?: number; maxGates?: number }): void {
+    public mutate(network: Network, options?: { maxNodes?: number; maxConnections?: number; maxGates?: number, allowedActivations?: ActivationType[] }): void {
         // check if max nodes is already reached
         if (options !== undefined && options.maxNodes !== undefined && network.nodes.length >= options.maxNodes) {
             return;
@@ -135,7 +135,7 @@ export class SubNodeMutation extends Mutation {
  * myNetwork.mutate(new AddConnectionMutation()); // creates a random forward pointing connection
  */
 export class AddConnectionMutation extends Mutation {
-    public mutate(network: Network, options?: { maxNodes?: number; maxConnections?: number; maxGates?: number }): void {
+    public mutate(network: Network, options?: { maxNodes?: number; maxConnections?: number; maxGates?: number, allowedActivations?: ActivationType[] }): void {
         // check if max connections is already reached
         if (options !== undefined && options.maxConnections !== undefined && network.connections.length >= options.maxConnections) {
             return;
@@ -265,12 +265,12 @@ export class ModActivationMutation extends Mutation {
         this.mutateOutput = mutateOutput;
     }
 
-    public mutate(network: Network, options?: { maxNodes?: number; maxConnections?: number; maxGates?: number }): void {
+    public mutate(network: Network, options?: { maxNodes?: number; maxConnections?: number; maxGates?: number, allowedActivations?: ActivationType[] }): void {
         const possible: Node[] = this.mutateOutput
             ? network.nodes.filter(node => !node.isInputNode()) // hidden and output nodes
             : network.nodes.filter(node => node.isHiddenNode()); // hidden nodes
         if (possible.length > 0) {
-            pickRandom(possible).mutateActivation(); // mutate the activation of the node
+            pickRandom(possible).mutateActivation(options?.allowedActivations); // mutate the activation of the node
         }
     }
 }
@@ -329,7 +329,7 @@ export class SubSelfConnectionMutation extends Mutation {
  * myNetwork.mutate(new AddGateMutation());
  */
 export class AddGateMutation extends Mutation {
-    public mutate(network: Network, options?: { maxNodes?: number; maxConnections?: number; maxGates?: number }): void {
+    public mutate(network: Network, options?: { maxNodes?: number; maxConnections?: number; maxGates?: number, allowedActivations?: ActivationType[] }): void {
         // check if max gates isn't reached already
         if (options !== undefined && options.maxGates !== undefined && network.gates.length >= options.maxGates) {
             return;

--- a/test/e2e/LogicGatesTest.ts
+++ b/test/e2e/LogicGatesTest.ts
@@ -63,7 +63,7 @@ describe('Logic Gates', () => {
         expect(final).to.be.at.most(initial);
     });
     it('[NOT] Network.evolve()', async function (): Promise<void> {
-        this.timeout(30000);
+        this.timeout(40000);
 
         const network: Network = new Network(1, 1);
 
@@ -84,7 +84,7 @@ describe('Logic Gates', () => {
         expect(final).to.be.at.most(initial);
     });
     it('[AND] Network.evolve()', async function (): Promise<void> {
-        this.timeout(30000);
+        this.timeout(40000);
 
         const network: Network = new Network(2, 1);
 
@@ -105,7 +105,7 @@ describe('Logic Gates', () => {
         expect(final).to.be.at.most(initial);
     });
     it('[OR] Network.evolve()', async function (): Promise<void> {
-        this.timeout(30000);
+        this.timeout(40000);
 
         const network: Network = new Network(2, 1);
 
@@ -126,7 +126,7 @@ describe('Logic Gates', () => {
         expect(final).to.be.at.most(initial);
     });
     it('[NAND] Network.evolve()', async function (): Promise<void> {
-        this.timeout(30000);
+        this.timeout(40000);
 
         const network: Network = new Network(2, 1);
 
@@ -147,7 +147,7 @@ describe('Logic Gates', () => {
         expect(final).to.be.at.most(initial);
     });
     it('[NOR] Network.evolve()', async function (): Promise<void> {
-        this.timeout(30000);
+        this.timeout(40000);
 
         const network: Network = new Network(2, 1);
 
@@ -168,7 +168,7 @@ describe('Logic Gates', () => {
         expect(final).to.be.at.most(initial);
     });
     it('[XOR] Network.evolve()', async function (): Promise<void> {
-        this.timeout(30000);
+        this.timeout(60000);
 
         const network: Network = new Network(2, 1);
 
@@ -189,7 +189,7 @@ describe('Logic Gates', () => {
         expect(final).to.be.at.most(initial);
     });
     it('[XNOR] Network.evolve()', async function (): Promise<void> {
-        this.timeout(30000);
+        this.timeout(60000);
 
         const network: Network = new Network(2, 1);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,14 @@
     ],
     "allowJs": false,
     "outDir": "build",
-    "rootDir": "./src",
+    "rootDir": "./",
     "strict": true,
     "noImplicitAny": true,
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "test/**/*"
   ]
 }


### PR DESCRIPTION
Similiar to define the allowed mutations, you can now set an array of activation functions the evolved network can have.