### PR TITLE
Elitism not sorted in next generation

### DIFF
--- a/src/neat.js
+++ b/src/neat.js
@@ -460,7 +460,7 @@ const Neat = function(inputs, outputs, dataset, options) {
 
     // Elitism, assumes population is sorted by fitness
     const elitists = []
-    for (let i = 0; i < self.elitism; i++) elitists.push(population[i].clone())
+    for (let i = 0; i < self.elitism; i++) elitists.unshift(population[i].clone())
 
     // Provenance
     const new_population = []


### PR DESCRIPTION
By adding the elitist at the beginning, next generation will have the best at the beginning instead of being mixed up with the mutated ones.