### PR TITLE
Fix incorrect array slicing parameters

### DIFF
--- a/src/architecture/architect.js
+++ b/src/architecture/architect.js
@@ -274,7 +274,7 @@ const architect = {
       layer_sizes = layer_sizes_and_options;
       options = {};
     } else {
-      layer_sizes = layer_sizes_and_options.slice(layer_sizes_and_options.length - 1);
+      layer_sizes = layer_sizes_and_options.slice(0, -1);
       options = output_size_or_options;
     }
 


### PR DESCRIPTION
Ugh I keep getting this error. I put in so many layers!!!!
![image](https://user-images.githubusercontent.com/58114641/102023242-9cf6d700-3d51-11eb-9020-27657d174c23.png)

I looked at the code to try to do it myself but I ended up finding a bug instead.

Code changed:
Array.slice(0, -1) instead of Array.slice(Start at length - 1)
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice