### PR TITLE
Replacing Travis CI with github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test using node js version ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js  
-node_js:  
-  - "node"
-  
-after_success: npm run coverage

--- a/package.json
+++ b/package.json
@@ -14,11 +14,10 @@
     "last 1 Chrome version"
   ],
   "scripts": {
-    "coverage": "./node_modules/.bin/nyc report --reporter=text-lcov | coveralls && rm -rf ./src-cov",
     "build:src": "concurrently 'node scripts/src.build.node.js' 'node scripts/src.build.browser.js'",
     "build:src:webpack": "./node_modules/.bin/webpack",
     "deploy:docs": "node theme/deploy-docs.js",
-    "test": "./node_modules/.bin/nyc --reporter=html --reporter=text node ./node_modules/mocha/bin/mocha --recursive test/ --exclude test/unit.js",
+    "test": "./node_modules/.bin/nyc --reporter=lcov --reporter=text node ./node_modules/mocha/bin/mocha --recursive test/ --exclude test/unit.js",
     "lint": "./node_modules/.bin/eslint --ignore-path .eslintignore .",
     "test:debug": "./node_modules/.bin/nyc --reporter=html --reporter=text node ./node_modules/mocha/bin/mocha inspect --recursive test/ --exclude test/unit.js",
     "test:forever": "./node_modules/.bin/nodemon ./node_modules/.bin/mocha --reporter spec test/"


### PR DESCRIPTION
We should remove travis ci, as the github ci is much faster and simpler.